### PR TITLE
Added retry mechanism that will retry calls to Elasticsearch, waiting…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/


### PR DESCRIPTION
… for 30 seconds between calls.

This was needed as we start all out docker containers at the same time so the Elasticsearch container may not be up and running with a test requests test data.